### PR TITLE
Add Multiwfn oracle consistency verifier

### DIFF
--- a/.github/workflows/consistency-verifier.yml
+++ b/.github/workflows/consistency-verifier.yml
@@ -1,0 +1,41 @@
+name: Multiwfn Oracle Consistency
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run the oracle smoke suite daily at 03:00 UTC.
+    - cron: "0 3 * * *"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Verify retained oracle binary
+        run: |
+          test -x Multiwfn_3.8_bin_Linux_noGUI/Multiwfn
+          file Multiwfn_3.8_bin_Linux_noGUI/Multiwfn
+
+      - name: Run smoke oracle parity
+        run: python -m consistency_verifier run --suite smoke
+
+      - name: Upload verifier reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: consistency-verifier-smoke
+          path: consistency_verifier/results/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ output_*.txt
 *_pymultiwfn.txt
 *_diff.txt
 test_reports/
+consistency_verifier/results/
 *.cube
 *.grid
 *.dens

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ pytest -n auto
 # Run with coverage
 pytest --cov=pymultiwfn --cov-report=html
 
+# Run Multiwfn oracle consistency smoke checks on Linux
+python -m consistency_verifier run --suite smoke
+
 # Install local git quality gates
 pre-commit install --install-hooks
 ```

--- a/architecture_plan.md
+++ b/architecture_plan.md
@@ -32,6 +32,14 @@ This repository is maintained as an installable Python package plus a tracked re
 - Remove generated caches and build artifacts from the working tree before commits.
 - Keep `architecture_plan.md` updated when repository boundaries, module responsibilities, or progress status changes.
 
+### 0.4 Multiwfn Oracle Consistency Workflow
+
+- `consistency_verifier/` is the internal parity harness for comparing PyMultiWFN with the retained Multiwfn 3.8 noGUI binary.
+- `python -m consistency_verifier run --suite smoke|pr|full` is the canonical entry point for local, CI, and nightly verification.
+- Case manifests live in `consistency_verifier/cases/*.json`; generated transcripts and JSON reports live under ignored `consistency_verifier/results/`.
+- `smoke` covers fast metadata parity, `pr` adds representative density/gradient/bond/orbital observations, and `full` is the nightly expansion layer for larger retained examples.
+- The retained Linux binary is the behavior oracle. The upstream source directory remains a reference for explaining and migrating algorithms, not for package installation or test execution.
+
 ## 1. 现有项目结构分析 (Reconnaissance)
 
 ### 1.1 文件类型与分布

--- a/consistency_verifier/README.md
+++ b/consistency_verifier/README.md
@@ -1,214 +1,57 @@
 # PyMultiWFN Consistency Verifier
 
-A comprehensive testing suite to ensure PyMultiWFN outputs are consistent with the original Multiwfn program.
+This package-local tool compares PyMultiWFN against the retained Multiwfn 3.8
+noGUI binary. It is intended for repository development, CI, and nightly parity
+checks; it is not part of the installable `pymultiwfn` Python package.
 
-## Overview
+## Oracle Boundary
 
-This testing framework automatically runs both Multiwfn and PyMultiWFN on a variety of test cases and compares their outputs using intelligent matching algorithms that account for:
+- Oracle binary: `Multiwfn_3.8_bin_Linux_noGUI/Multiwfn`
+- Oracle examples: `Multiwfn_3.8_bin_Linux_noGUI/examples/`
+- Upstream source: `Multiwfn_3.8_dev_src_Linux_2025-Nov-23/`
 
-- Exact string matching for identical outputs
-- Tolerance-based numeric comparison for floating-point values
-- Output normalization to handle version differences, formatting variations, and irrelevant metadata
-
-## Files Structure
-
-```
-consistency_verifier/
-├── verifier.py          # Core verification logic
-├── test_runner.py       # Comprehensive test suite
-├── quick_test.py        # Quick function testing
-├── run_tests.bat        # Windows batch runner
-├── requirements.txt     # Python dependencies
-├── README.md           # This file
-└── test_reports/       # Generated test reports
-```
-
-## Requirements
-
-- Python 3.8+
-- NumPy
-- Multiwfn 3.8 executable
-- PyMultiWFN installed in development mode
-
-## Installation
-
-1. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-2. Ensure PyMultiWFN is installed:
-   ```bash
-   pip install -e ..
-   ```
-
-3. Download and extract Multiwfn 3.8 to `../Multiwfn_3.8_dev_bin_Win64/`
+The upstream source directory is for algorithm inspection and migration review.
+The verifier's behavior standard comes from the retained noGUI binary output.
 
 ## Usage
 
-### Quick Testing
+```bash
+python -m consistency_verifier run --suite smoke
+python -m consistency_verifier run --suite pr
+python -m consistency_verifier run --suite full
+```
 
-Test specific functions quickly:
+To use a different executable:
 
 ```bash
-# Quick test of all functions on a default file
-python quick_test.py
-
-# Test specific function
-python quick_test.py --function density
-
-# Test with custom file
-python quick_test.py --file path/to/test.wfn
+MULTIWFN_BIN=/path/to/Multiwfn python -m consistency_verifier run --suite smoke
 ```
 
-### Comprehensive Testing
-
-Run full test suite on all examples:
+The shell wrappers delegate to the same entry point:
 
 ```bash
-# Run comprehensive tests
-python test_runner.py
-
-# Run sequentially (slower but easier debugging)
-python test_runner.py --parallel 0
+consistency_verifier/run_tests.sh smoke
+consistency_verifier/run_tests.sh pr
+consistency_verifier/run_tests.sh full
 ```
 
-### Windows Batch Runner
+## Suites
 
-Use the provided batch script for easy execution:
+- `smoke`: fast metadata parity over a small H2/H2O/benzene set.
+- `pr`: includes `smoke` plus representative density, gradient, bond-order,
+  and orbital observations for PR triage.
+- `full`: includes `smoke` and `pr` plus larger retained reference assets for
+  nightly expansion.
 
-```cmd
-# Quick tests
-run_tests.bat quick
+## Manifests
 
-# Full comprehensive tests
-run_tests.bat
+Cases live in `consistency_verifier/cases/*.json`. Each case records:
 
-# Sequential execution
-run_tests.bat sequential
-```
+- input file path, resolved from the repository root
+- scripted Multiwfn menu commands
+- PyMultiWFN observations to collect
+- comparison fields, comparison kind, and tolerances
+- optional regex extractors for additional oracle fields
 
-## Test Coverage
-
-The framework tests the following Multiwfn functions:
-
-- **Basic Information** (Function 0): Molecular data, atom counts, basis sets
-- **Electron Density** (Function 1): Critical points, density analysis
-- **Molecular Orbitals** (Function 5): Orbital energies, coefficients
-- **Population Analysis** (Function 7): Mulliken charges, populations
-- **Dipole Moment** (Function 11): Molecular dipole calculation
-- **Electrostatic Potential** (Function 12): ESP mapping and analysis
-- **Band Gap** (Function 17): HOMO-LUMO gap analysis
-- **NCI Analysis** (Function 20): Non-covalent interaction analysis
-
-## Supported File Formats
-
-- `.wfn` - Wavefunction files
-- `.fch` / `.fchk` - Gaussian formatted checkpoint files
-- `.molden` - Molden format files
-- `.wfx` - Extended wavefunction files
-
-## Output Reports
-
-The testing framework generates three types of reports:
-
-1. **Summary Report** (`test_summary_*.json`): Overall statistics and pass/fail rates
-2. **Human-Readable Report** (`test_report_*.txt`): Formatted text report
-3. **Detailed Results** (`detailed_results_*.json`): Complete comparison data for all tests
-
-Reports are saved in the `test_reports/` directory with timestamps.
-
-## Understanding Test Results
-
-### Success Criteria
-
-A test passes if:
-- Both programs execute without errors, AND
-- Outputs match exactly, OR
-- Numerical values match within specified tolerance (default: 1e-5)
-
-### Report Sections
-
-- **Overall Summary**: Pass/fail statistics, success rate
-- **Failure Breakdown**: Types of failures and their frequency
-- **Detailed Results**: Per-file and per-function analysis
-
-### Comparison Types
-
-- **Exact Match**: String comparison after normalization
-- **Numeric Tolerance**: Numerical values match within tolerance when exact strings differ
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Multiwfn not found**: Ensure Multiwfn.exe is in the correct location
-2. **PyMultiWFN import errors**: Install PyMultiWFN in development mode
-3. **Permission errors**: Run with appropriate file permissions
-4. **Timeout errors**: Increase timeout values in the verifier
-
-### Debug Mode
-
-For debugging, run tests sequentially to see detailed output:
-
-```python
-# In test_runner.py, set parallel=False
-summary = suite.run_all_tests(parallel=False)
-```
-
-## Contributing
-
-To add new test cases:
-
-1. Add test files to the Multiwfn examples directory
-2. Define new test configurations in `test_configs` or `advanced_configs`
-3. Update file categorization logic if needed
-4. Add appropriate patterns for output parsing
-
-## Output Normalization
-
-The framework automatically handles:
-
-- Version number differences
-- Compilation date variations
-- Scientific notation formatting (1.23E-01 vs 1.23e-01)
-- Whitespace normalization
-- Timing information removal
-- Reference text removal
-
-## Configuration Options
-
-Key parameters can be adjusted in the code:
-
-- `tolerance`: Numeric comparison tolerance (default: 1e-5)
-- `timeout`: Process timeout in seconds (default: 60)
-- `max_workers`: Parallel execution workers
-- `skip_patterns`: Output lines to ignore during comparison
-
-
-
-
-  "Building upon the existing consistency_verifier/README.md, the first step is to establish the basic execution  
-  of both the original Multiwfn program and the pymultiwfn library on a single test file.                         
-
-
-
-
-1. Create a placeholder `verifier.py` in C:\Users\yanha\Downloads\PyMultiWFN\consistency_verifier\ if it       
-   doesn't already exist.
-2. Implement a function within `verifier.py` (e.g., run_multiwfn_and_pymultiwfn) that takes a file path to an  
-   example input file (e.g., from C:\Users\yanha\Downloads\PyMultiWFN\Multiwfn_3.8_dev_bin_Win64\examples\) as 
-   an argument.
-3. Within this function, execute `Multiwfn.exe`:(or corresponding file in linux or mac OS)
-      * Determine the correct command-line arguments to run Multiwfn.exe non-interactively on the input file to  
-      generate a specific output (e.g., Function 0: Molecular data). You may need to consult Multiwfn
-      documentation or experiment.
-      * Capture its standard output and standard error.
-4. Execute `pymultiwfn`:
-      * Identify the equivalent pymultiwfn function or module that processes the same input file and performs the
-      same analysis as Multiwfn in the previous step.
-      * Capture its output (e.g., returned data structure or printed output).
-5. For initial verification, print both raw outputs (Multiwfn and pymultiwfn) to the console for a selected    
-   example file.
-
-Goal: To confirm that both programs can be invoked programmatically and their raw outputs can be captured for a simple case.
+Generated reports and transcripts are written to
+`consistency_verifier/results/<run-id>/` and are intentionally ignored by git.

--- a/consistency_verifier/VERIFICATION.md
+++ b/consistency_verifier/VERIFICATION.md
@@ -1,31 +1,33 @@
 # Consistency Verification
 
-This project includes a tool to verify the consistency between `PyMultiWFN` and the original `Multiwfn`.
+Run parity checks from the repository root:
 
-## Prerequisites
+```bash
+python -m consistency_verifier run --suite smoke
+python -m consistency_verifier run --suite pr
+python -m consistency_verifier run --suite full
+```
 
-1.  **Multiwfn Executable**: You need a working `Multiwfn` executable.
-    *   If you are on Windows, ensure `Multiwfn.exe` is accessible.
-    *   If you are on Linux/WSL, ensure the `Multiwfn` binary is compiled and accessible.
-2.  **PyMultiWFN**: Installed via pip (e.g., `pip install -e .`).
+The default oracle is:
 
-## Usage
+```text
+Multiwfn_3.8_bin_Linux_noGUI/Multiwfn
+```
 
-1.  Set the `MULTIWFN_BIN` environment variable to the path of your Multiwfn executable.
-    *   Windows (PowerShell): `$env:MULTIWFN_BIN = "C:\path\to\Multiwfn.exe"`
-    *   Linux/Bash: `export MULTIWFN_BIN=/path/to/Multiwfn`
-    
-    Alternatively, you can edit `run_verification.py` directly.
+Override it with `MULTIWFN_BIN` or `--multiwfn-bin` when needed.
 
-2.  Run the verification script:
-    ```bash
-    python run_verification.py
-    ```
+```bash
+MULTIWFN_BIN=/path/to/Multiwfn python -m consistency_verifier run --suite smoke
+python -m consistency_verifier run --suite smoke --multiwfn-bin /path/to/Multiwfn
+```
 
-## How it works
+The retained oracle binary is a Linux x86-64 executable. On non-Linux developer
+machines, use the unit tests for the harness and run live oracle parity in a
+Linux environment.
 
-The `ConsistencyVerifier` class (in `consistency_verifier/verifier.py`) runs both programs with the same input file and keystrokes. It captures the standard output and compares them line by line.
+Reports are written under `consistency_verifier/results/<run-id>/` and include:
 
-## Adding Test Cases
-
-To add more test cases, modify `run_verification.py` to include different input files and command sequences.
+- `report.json`
+- raw Multiwfn stdout/stderr transcripts
+- structured PyMultiWFN values
+- per-case comparison results

--- a/consistency_verifier/__init__.py
+++ b/consistency_verifier/__init__.py
@@ -1,1 +1,19 @@
-from .verifier import ConsistencyVerifier
+from .verifier import (
+    CaseSpec,
+    ComparisonSpec,
+    ConsistencyVerifier,
+    MultiwfnOracle,
+    compare_value,
+    extract_reference_values,
+    load_case_specs,
+)
+
+__all__ = [
+    "CaseSpec",
+    "ComparisonSpec",
+    "ConsistencyVerifier",
+    "MultiwfnOracle",
+    "compare_value",
+    "extract_reference_values",
+    "load_case_specs",
+]

--- a/consistency_verifier/__main__.py
+++ b/consistency_verifier/__main__.py
@@ -1,0 +1,7 @@
+"""Command-line entry point for ``python -m consistency_verifier``."""
+
+from .verifier import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/consistency_verifier/cases/full.json
+++ b/consistency_verifier/cases/full.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "description": "Nightly/full-suite seed cases for larger retained reference assets.",
+  "cases": [
+    {
+      "id": "full_phenanthrene_metadata",
+      "suite": "full",
+      "input": "Multiwfn_3.8_bin_Linux_noGUI/examples/phenanthrene.wfn",
+      "multiwfn": {
+        "commands": ["18", "1", "q"],
+        "timeout_seconds": 90
+      },
+      "pymultiwfn": {
+        "density_points": [[0.0, 0.0, 0.0]]
+      },
+      "comparisons": [
+        {"field": "num_atoms", "kind": "int"},
+        {"field": "num_electrons", "kind": "float", "tolerance": 1e-8},
+        {"field": "charge", "kind": "float", "tolerance": 1e-8},
+        {"field": "num_orbitals", "kind": "int", "required": false}
+      ]
+    }
+  ]
+}

--- a/consistency_verifier/cases/pr.json
+++ b/consistency_verifier/cases/pr.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "description": "Representative PR-layer observations for numerical parity triage.",
+  "cases": [
+    {
+      "id": "pr_h2_density_gradient_orbitals",
+      "suite": "pr",
+      "input": "Multiwfn_3.8_bin_Linux_noGUI/examples/H2_CCSD.wfn",
+      "multiwfn": {
+        "commands": ["18", "1", "q"],
+        "timeout_seconds": 45
+      },
+      "pymultiwfn": {
+        "density_points": [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        "gradient_points": [[0.0, 0.0, 0.0]]
+      },
+      "comparisons": [
+        {"field": "num_atoms", "kind": "int"},
+        {"field": "num_electrons", "kind": "float", "tolerance": 1e-8},
+        {"field": "charge", "kind": "float", "tolerance": 1e-8},
+        {"field": "num_orbitals", "kind": "int", "required": false}
+      ]
+    },
+    {
+      "id": "pr_c2h2_bond_orders",
+      "suite": "pr",
+      "input": "Multiwfn_3.8_bin_Linux_noGUI/examples/C2H2.wfn",
+      "multiwfn": {
+        "commands": ["18", "1", "q"],
+        "timeout_seconds": 45
+      },
+      "pymultiwfn": {
+        "bond_pairs": [[1, 2]],
+        "density_points": [[0.0, 0.0, 0.0]]
+      },
+      "comparisons": [
+        {"field": "num_atoms", "kind": "int"},
+        {"field": "num_electrons", "kind": "float", "tolerance": 1e-8},
+        {"field": "charge", "kind": "float", "tolerance": 1e-8}
+      ]
+    },
+    {
+      "id": "pr_benzene_orbital_metadata",
+      "suite": "pr",
+      "input": "Multiwfn_3.8_bin_Linux_noGUI/examples/benzene.fch",
+      "multiwfn": {
+        "commands": ["18", "1", "q"],
+        "timeout_seconds": 45
+      },
+      "pymultiwfn": {
+        "density_points": [[0.0, 0.0, 0.0]]
+      },
+      "comparisons": [
+        {"field": "num_atoms", "kind": "int"},
+        {"field": "num_electrons", "kind": "float", "tolerance": 1e-8},
+        {"field": "charge", "kind": "float", "tolerance": 1e-8},
+        {"field": "num_basis", "kind": "int", "required": false}
+      ]
+    }
+  ]
+}

--- a/consistency_verifier/cases/smoke.json
+++ b/consistency_verifier/cases/smoke.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "description": "Fast oracle checks for basic Multiwfn/PyMultiWFN metadata parity.",
+  "cases": [
+    {
+      "id": "smoke_h2_metadata",
+      "suite": "smoke",
+      "input": "Multiwfn_3.8_bin_Linux_noGUI/examples/H2_CCSD.wfn",
+      "multiwfn": {
+        "commands": ["18", "1", "q"],
+        "timeout_seconds": 30
+      },
+      "comparisons": [
+        {"field": "num_atoms", "kind": "int"},
+        {"field": "num_electrons", "kind": "float", "tolerance": 1e-8},
+        {"field": "charge", "kind": "float", "tolerance": 1e-8},
+        {"field": "num_orbitals", "kind": "int", "required": false}
+      ]
+    },
+    {
+      "id": "smoke_water_metadata",
+      "suite": "smoke",
+      "input": "Multiwfn_3.8_bin_Linux_noGUI/examples/H2O.fch",
+      "multiwfn": {
+        "commands": ["18", "1", "q"],
+        "timeout_seconds": 30
+      },
+      "comparisons": [
+        {"field": "num_atoms", "kind": "int"},
+        {"field": "num_electrons", "kind": "float", "tolerance": 1e-8},
+        {"field": "charge", "kind": "float", "tolerance": 1e-8},
+        {"field": "num_basis", "kind": "int", "required": false}
+      ]
+    },
+    {
+      "id": "smoke_benzene_metadata",
+      "suite": "smoke",
+      "input": "Multiwfn_3.8_bin_Linux_noGUI/examples/benzene.fch",
+      "multiwfn": {
+        "commands": ["18", "1", "q"],
+        "timeout_seconds": 30
+      },
+      "comparisons": [
+        {"field": "num_atoms", "kind": "int"},
+        {"field": "num_electrons", "kind": "float", "tolerance": 1e-8},
+        {"field": "charge", "kind": "float", "tolerance": 1e-8},
+        {"field": "num_basis", "kind": "int", "required": false}
+      ]
+    }
+  ]
+}

--- a/consistency_verifier/quick_test.py
+++ b/consistency_verifier/quick_test.py
@@ -1,85 +1,14 @@
 #!/usr/bin/env python3
-"""
-Quick consistency test for PyMultiWFN
-Run this script to quickly verify that PyMultiWFN matches Multiwfn results
-"""
+"""Run the smoke consistency verifier suite."""
 
-import os
+from __future__ import annotations
+
 import sys
-import subprocess
+from pathlib import Path
 
-# Set Multiwfn path
-os.environ["MULTIWFN_BIN"] = (
-    "/home/yhm/software/PyMultiWFN/Multiwfn_3.8_bin_Linux_noGUI/Multiwfn"
-)
-
-# Test file
-TEST_FILE = "/home/yhm/software/PyMultiWFN/consistency_verifier/examples/H2_CCSD.wfn"
-
-
-def run_consistency_test():
-    print("=" * 60)
-    print("PyMultiWFN Consistency Quick Test")
-    print("=" * 60)
-    print(f"Test file: {TEST_FILE}")
-    print(f"Multiwfn: {os.environ.get('MULTIWFN_BIN')}")
-    print("")
-
-    # Test 1: Load with PyMultiWFN
-    print("[1/3] Loading with PyMultiWFN...")
-    try:
-        from pymultiwfn.io.file_manager import FileManager
-
-        fm = FileManager()
-        wfn = fm.load_wavefunction(TEST_FILE)
-        py_electrons = wfn.num_electrons
-        py_charge = wfn.charge
-        py_atoms = len(wfn.atoms)
-        print(f"  ✓ Electrons: {py_electrons}")
-        print(f"  ✓ Charge: {py_charge}")
-        print(f"  ✓ Atoms: {py_atoms}")
-    except Exception as e:
-        print(f"  ✗ Error: {e}")
-        return 1
-
-    # Test 2: Run with Multiwfn
-    print("\n[2/3] Running with Multiwfn...")
-    try:
-        result = subprocess.run(
-            [os.environ["MULTIWFN_BIN"], TEST_FILE],
-            input="18\n1\nq\n",
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        output = result.stdout
-
-        # Parse electrons from output
-        for line in output.split("\n"):
-            if "Total/Alpha/Beta electrons:" in line:
-                parts = line.split(":")
-                if len(parts) > 1:
-                    mw_electrons = float(parts[1].strip())
-                    print(f"  ✓ Electrons: {mw_electrons}")
-                    break
-    except Exception as e:
-        print(f"  ✗ Error: {e}")
-        return 1
-
-    # Compare
-    print("\n[3/3] Comparing results...")
-    if abs(py_electrons - mw_electrons) < 0.001:
-        print(f"  ✓ Electrons match: {py_electrons} == {mw_electrons}")
-        print("\n✅ CONSISTENCY CHECK PASSED")
-        print("=" * 60)
-        return 0
-    else:
-        print(f"  ✗ Electrons mismatch: {py_electrons} != {mw_electrons}")
-        print(f"    Difference: {abs(py_electrons - mw_electrons)}")
-        print("\n❌ CONSISTENCY CHECK FAILED")
-        print("=" * 60)
-        return 1
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from consistency_verifier.verifier import main
 
 
 if __name__ == "__main__":
-    sys.exit(run_consistency_test())
+    raise SystemExit(main(["run", "--suite", "smoke", *sys.argv[1:]]))

--- a/consistency_verifier/quick_test_v2.py
+++ b/consistency_verifier/quick_test_v2.py
@@ -1,95 +1,14 @@
 #!/usr/bin/env python3
-"""
-Quick consistency test for PyMultiWFN v2
-Run this script to quickly verify that PyMultiWFN matches Multiwfn results
-"""
+"""Compatibility wrapper for the smoke consistency verifier suite."""
 
-import os
+from __future__ import annotations
+
 import sys
-import subprocess
-import re
+from pathlib import Path
 
-# Set Multiwfn path
-os.environ["MULTIWFN_BIN"] = (
-    "/home/yhm/software/PyMultiWFN/Multiwfn_3.8_bin_Linux_noGUI/Multiwfn"
-)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from consistency_verifier.verifier import main
 
-# Test file
-TEST_FILE = "/home/yhm/software/PyMultiWFN/consistency_verifier/examples/H2_CCSD.wfn"
 
-print("=" * 60)
-print("PyMultiWFN Consistency Quick Test v2")
-print("=" * 60)
-print(f"Test file: {TEST_FILE}")
-print(f"Multiwfn: {os.environ.get('MULTIWFN_BIN')}")
-print("")
-
-# Test 1: Load with PyMultiWFN
-print("[1/3] Loading with PyMultiWFN...")
-try:
-    # First, try installing in editable mode
-    subprocess.run(["pip", "install", "-e", "."], capture_output=True, check=True)
-
-    from pymultiwfn.io.file_manager import FileManager
-
-    fm = FileManager()
-    wfn = fm.load_wavefunction(TEST_FILE)
-    py_electrons = wfn.num_electrons
-    py_charge = wfn.charge
-    py_atoms = len(wfn.atoms)
-    print(f"  ✓ Electrons: {py_electrons}")
-    print(f"  ✓ Charge: {py_charge}")
-    print(f"  ✓ Atoms: {py_atoms}")
-except Exception as e:
-    print(f"  ✗ Error: {e}")
-    import traceback
-
-    traceback.print_exc()
-    sys.exit(1)
-
-# Test 2: Run with Multiwfn
-print("\n[2/3] Running with Multiwfn...")
-try:
-    result = subprocess.run(
-        [os.environ["MULTIWFN_BIN"], TEST_FILE],
-        input="18\n1\nq\n",
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    output = result.stdout
-
-    # Parse electrons from output - look for the line with total electrons
-    for line in output.split("\n"):
-        if "Total/Alpha/Beta electrons:" in line:
-            # Extract the number after the colon
-            match = re.search(r"Total/Alpha/Beta electrons:\s+([\d.]+)", line)
-            if match:
-                mw_electrons = float(match.group(1))
-                print(f"  ✓ Electrons: {mw_electrons}")
-                break
-        # Also check for net charge
-        if "Net charge:" in line:
-            match = re.search(r"Net charge:\s+([\-\d.]+)", line)
-            if match:
-                print(f"  ✓ Net charge: {match.group(1)}")
-except Exception as e:
-    print(f"  ✗ Error: {e}")
-    import traceback
-
-    traceback.print_exc()
-    sys.exit(1)
-
-# Compare
-print("\n[3/3] Comparing results...")
-if abs(py_electrons - mw_electrons) < 0.001:
-    print(f"  ✓ Electrons match: {py_electrons} == {mw_electrons}")
-    print("\n✅ CONSISTENCY CHECK PASSED")
-    print("=" * 60)
-    sys.exit(0)
-else:
-    print(f"  ✗ Electrons mismatch: {py_electrons} != {mw_electrons}")
-    print(f"    Difference: {abs(py_electrons - mw_electrons)}")
-    print("\n❌ CONSISTENCY CHECK FAILED")
-    print("=" * 60)
-    sys.exit(1)
+if __name__ == "__main__":
+    raise SystemExit(main(["run", "--suite", "smoke", *sys.argv[1:]]))

--- a/consistency_verifier/run_tests.bat
+++ b/consistency_verifier/run_tests.bat
@@ -1,65 +1,34 @@
 @echo off
-REM Windows batch script for running PyMultiWFN consistency tests
+REM PyMultiWFN consistency verifier wrapper for Windows shells.
 
-echo PyMultiWFN Consistency Test Runner
-echo ==================================
+setlocal
 
-REM Set Python environment
-python --version >nul 2>&1
-if %errorlevel% neq 0 (
-    echo Error: Python not found in PATH
-    exit /b 1
-)
-
-REM Check if PyMultiWFN is available
-python -c "import pymultiwfn" >nul 2>&1
-if %errorlevel% neq 0 (
-    echo Error: PyMultiWFN not found or not installed
-    echo Please install PyMultiWFN first: pip install -e .
-    exit /b 1
-)
-
-REM Get script directory
 set SCRIPT_DIR=%~dp0
 set PROJECT_ROOT=%SCRIPT_DIR%..
+set SUITE=smoke
+set RESULTS_DIR=%PROJECT_ROOT%\consistency_verifier\results
 
-REM Check Multiwfn executable
-set MULTIWFN_EXE=%PROJECT_ROOT%\Multiwfn_3.8_dev_bin_Win64\Multiwfn.exe
-if not exist "%MULTIWFN_EXE%" (
-    echo Error: Multiwfn executable not found at:
-    echo %MULTIWFN_EXE%
-    echo Please ensure Multiwfn is properly extracted
-    exit /b 1
-)
-
-echo Found Multiwfn: %MULTIWFN_EXE%
-
-REM Parse command line arguments
-set TEST_TYPE=all
-set PARALLEL=1
-
-if "%1"=="quick" set TEST_TYPE=quick
-if "%1"=="parallel" set PARALLEL=1
-if "%1"=="sequential" set PARALLEL=0
-
-echo Test Type: %TEST_TYPE%
-echo Parallel Mode: %PARALLEL%
-echo.
-
-REM Create output directory
-set REPORT_DIR=%PROJECT_ROOT%\consistency_verifier\test_reports
-if not exist "%REPORT_DIR%" mkdir "%REPORT_DIR%"
-
-if "%TEST_TYPE%"=="quick" (
-    echo Running quick tests...
-    python "%SCRIPT_DIR%quick_test.py" --multiwfn "%MULTIWFN_EXE%"
+if "%MULTIWFN_BIN%"=="" (
+    set MULTIWFN_EXE=%PROJECT_ROOT%\Multiwfn_3.8_bin_Linux_noGUI\Multiwfn
 ) else (
-    echo Running comprehensive test suite...
-    python "%SCRIPT_DIR%test_runner.py" --multiwfn "%MULTIWFN_EXE%" --examples "%PROJECT_ROOT%\Multiwfn_3.8_dev_bin_Win64\examples"
+    set MULTIWFN_EXE=%MULTIWFN_BIN%
 )
 
-echo.
-echo Test completed. Check the reports directory for detailed results.
-echo Reports location: %REPORT_DIR%
+if "%1"=="quick" set SUITE=smoke
+if "%1"=="smoke" set SUITE=smoke
+if "%1"=="pr" set SUITE=pr
+if "%1"=="full" set SUITE=full
 
-pause
+echo PyMultiWFN consistency verifier
+python --version
+echo Suite: %SUITE%
+echo Multiwfn oracle: %MULTIWFN_EXE%
+echo Results: %RESULTS_DIR%
+echo.
+
+python -m consistency_verifier run ^
+    --suite "%SUITE%" ^
+    --multiwfn-bin "%MULTIWFN_EXE%" ^
+    --results-dir "%RESULTS_DIR%"
+
+endlocal

--- a/consistency_verifier/run_tests.sh
+++ b/consistency_verifier/run_tests.sh
@@ -1,211 +1,100 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# PyMultiWFN Consistency Test Runner for Linux/macOS
-# This script runs the consistency testing suite
+# PyMultiWFN consistency verifier wrapper.
 
-set -e  # Exit on any error
+set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-echo -e "${BLUE}PyMultiWFN Consistency Test Runner${NC}"
-echo -e "${BLUE}==================================${NC}"
-
-# Check if Python is available
-if ! command -v python3 &> /dev/null; then
-    if ! command -v python &> /dev/null; then
-        echo -e "${RED}Error: Python not found in PATH${NC}"
-        exit 1
-    else
-        PYTHON_CMD="python"
-    fi
-else
-    PYTHON_CMD="python3"
-fi
-
-# Check Python version
-PYTHON_VERSION=$($PYTHON_CMD --version 2>&1)
-echo -e "${GREEN}Python: $PYTHON_VERSION${NC}"
-
-# Check if PyMultiWFN is available
-if ! $PYTHON_CMD -c "import pymultiwfn" 2>/dev/null; then
-    echo -e "${RED}Error: PyMultiWFN not found or not installed${NC}"
-    echo -e "${YELLOW}Please install PyMultiWFN first: pip install -e .${NC}"
-    exit 1
-fi
-
-# Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PYTHON_CMD="${PYTHON:-python3}"
+SUITE="smoke"
+MULTIWFN_EXE="${MULTIWFN_BIN:-$PROJECT_ROOT/Multiwfn_3.8_bin_Linux_noGUI/Multiwfn}"
+RESULTS_DIR="$PROJECT_ROOT/consistency_verifier/results"
+EXTRA_ARGS=()
 
-# Check Multiwfn executable
-MULTIWFN_EXE=""
-# Try different possible locations
-MULTIWFN_PATHS=(
-    "$PROJECT_ROOT/Multiwfn_3.8_dev_bin_Win64/Multiwfn.exe"
-    "$PROJECT_ROOT/Multiwfn_3.8_dev_bin_Linux/Multiwfn"
-    "$PROJECT_ROOT/Multiwfn_3.8_dev_bin_Mac/Multiwfn"
-    "$PROJECT_ROOT/Multiwfn_3.8_dev_src_Linux_*/Multiwfn"
-    "/usr/local/bin/Multiwfn"
-    "/usr/bin/Multiwfn"
-)
+usage() {
+    cat <<USAGE
+Usage: $0 [smoke|quick|pr|full] [options]
 
-for path in "${MULTIWFN_PATHS[@]}"; do
-    if [[ -f "$path" ]] || [[ -L "$path" ]]; then
-        # Check if it's executable
-        if [[ -x "$path" ]] || [[ "$path" == *.exe ]]; then
-            MULTIWFN_EXE="$path"
-            break
-        fi
-    fi
-done
+Options:
+  --suite NAME       Run smoke, pr, or full
+  --multiwfn PATH    Path to the Multiwfn executable oracle
+  --results-dir DIR  Directory for generated verifier reports
+  --no-report        Do not write report files
+  --help, -h         Show this help message
 
-# Handle wildcard path
-if [[ -z "$MULTIWFN_EXE" ]]; then
-    for path in $PROJECT_ROOT/Multiwfn_3.8_dev_src_Linux_*/Multiwfn; do
-        if [[ -f "$path" ]] && [[ -x "$path" ]]; then
-            MULTIWFN_EXE="$path"
-            break
-        fi
-    done
-fi
-
-if [[ -z "$MULTIWFN_EXE" ]]; then
-    echo -e "${RED}Error: Multiwfn executable not found${NC}"
-    echo -e "${YELLOW}Searched locations:${NC}"
-    for path in "${MULTIWFN_PATHS[@]}"; do
-        echo "  - $path"
-    done
-    echo -e "${YELLOW}Please ensure Multiwfn is properly installed or specify the path with --multiwfn${NC}"
-    exit 1
-fi
-
-echo -e "${GREEN}Found Multiwfn: $MULTIWFN_EXE${NC}"
-
-# Parse command line arguments
-TEST_TYPE="all"
-PARALLEL="1"
-EXTRA_ARGS=""
+Environment:
+  PYTHON             Python executable to use
+  MULTIWFN_BIN       Default Multiwfn executable path
+USAGE
+}
 
 while [[ $# -gt 0 ]]; do
-    case $1 in
-        "quick")
-            TEST_TYPE="quick"
+    case "$1" in
+        quick|smoke)
+            SUITE="smoke"
             shift
             ;;
-        "parallel")
-            PARALLEL="1"
+        pr)
+            SUITE="pr"
             shift
             ;;
-        "sequential")
-            PARALLEL="0"
+        full)
+            SUITE="full"
             shift
             ;;
-        "--multiwfn")
+        --suite)
+            SUITE="$2"
+            shift 2
+            ;;
+        --multiwfn)
             MULTIWFN_EXE="$2"
             shift 2
             ;;
-        "--examples")
-            EXAMPLES_DIR="$2"
+        --results-dir)
+            RESULTS_DIR="$2"
             shift 2
             ;;
-        "--help"|"-h")
-            echo "Usage: $0 [quick|parallel|sequential] [--multiwfn PATH] [--examples PATH]"
-            echo ""
-            echo "Options:"
-            echo "  quick      Run quick tests only"
-            echo "  parallel   Run tests in parallel (default)"
-            echo "  sequential Run tests sequentially"
-            echo "  --multiwfn PATH   Specify Multiwfn executable path"
-            echo "  --examples PATH   Specify examples directory"
-            echo "  --help      Show this help message"
+        --no-report)
+            EXTRA_ARGS+=("--no-report")
+            shift
+            ;;
+        --skip-oracle-if-unavailable)
+            EXTRA_ARGS+=("--skip-oracle-if-unavailable")
+            shift
+            ;;
+        --help|-h)
+            usage
             exit 0
             ;;
         *)
-            EXTRA_ARGS="$EXTRA_ARGS $1"
+            EXTRA_ARGS+=("$1")
             shift
             ;;
     esac
 done
 
-echo -e "${BLUE}Configuration:${NC}"
-echo -e "  Test Type: ${YELLOW}$TEST_TYPE${NC}"
-echo -e "  Parallel Mode: ${YELLOW}$PARALLEL${NC}"
-echo ""
+case "$SUITE" in
+    smoke|pr|full)
+        ;;
+    *)
+        echo "Unknown suite: $SUITE" >&2
+        usage >&2
+        exit 2
+        ;;
+esac
 
-# Set default examples directory if not specified
-if [[ -z "$EXAMPLES_DIR" ]]; then
-    if [[ -d "$PROJECT_ROOT/Multiwfn_3.8_dev_bin_Win64/examples" ]]; then
-        EXAMPLES_DIR="$PROJECT_ROOT/Multiwfn_3.8_dev_bin_Win64/examples"
-    elif [[ -d "$PROJECT_ROOT/examples" ]]; then
-        EXAMPLES_DIR="$PROJECT_ROOT/examples"
-    else
-        echo -e "${YELLOW}Warning: Examples directory not found, using default${NC}"
-        EXAMPLES_DIR="$PROJECT_ROOT/Multiwfn_3.8_dev_bin_Win64/examples"
-    fi
-fi
-
-if [[ ! -d "$EXAMPLES_DIR" ]]; then
-    echo -e "${YELLOW}Warning: Examples directory not found at $EXAMPLES_DIR${NC}"
-    echo "Some tests may fail if example files are required"
-fi
-
-echo -e "${BLUE}Examples Directory: $EXAMPLES_DIR${NC}"
-echo ""
-
-# Create output directory
-REPORT_DIR="$PROJECT_ROOT/consistency_verifier/test_reports"
-mkdir -p "$REPORT_DIR"
-echo -e "${GREEN}Reports directory: $REPORT_DIR${NC}"
-
-# Change to project root to ensure relative imports work
 cd "$PROJECT_ROOT"
 
-# Run the tests
-if [[ "$TEST_TYPE" == "quick" ]]; then
-    echo -e "${BLUE}Running quick tests...${NC}"
-    if $PYTHON_CMD "$SCRIPT_DIR/quick_test.py" --multiwfn "$MULTIWFN_EXE" $EXTRA_ARGS; then
-        echo -e "${GREEN}✅ Quick tests completed successfully${NC}"
-    else
-        echo -e "${RED}❌ Quick tests failed${NC}"
-        exit 1
-    fi
-else
-    echo -e "${BLUE}Running comprehensive test suite...${NC}"
-    if $PYTHON_CMD "$SCRIPT_DIR/test_runner.py" \
-        --multiwfn "$MULTIWFN_EXE" \
-        --examples "$EXAMPLES_DIR" \
-        --parallel "$PARALLEL" $EXTRA_ARGS; then
-        echo -e "${GREEN}✅ Comprehensive tests completed successfully${NC}"
-    else
-        echo -e "${RED}❌ Comprehensive tests failed${NC}"
-        exit 1
-    fi
-fi
+echo "PyMultiWFN consistency verifier"
+echo "Python: $($PYTHON_CMD --version 2>&1)"
+echo "Suite: $SUITE"
+echo "Multiwfn oracle: $MULTIWFN_EXE"
+echo "Results: $RESULTS_DIR"
+echo
 
-echo ""
-echo -e "${GREEN}Test completed.${NC}"
-echo -e "${BLUE}Check the reports directory for detailed results:${NC}"
-echo -e "${YELLOW}$REPORT_DIR${NC}"
-
-# Show latest reports if they exist
-LATEST_REPORT=$(ls -t "$REPORT_DIR"/test_report_*.txt 2>/dev/null | head -1)
-if [[ -n "$LATEST_REPORT" ]]; then
-    echo ""
-    echo -e "${BLUE}Latest report summary:${NC}"
-    if [[ -f "$LATEST_REPORT" ]]; then
-        # Show first 20 lines of the report
-        head -20 "$LATEST_REPORT" | while IFS= read -r line; do
-            echo "  $line"
-        done
-        echo "  ..."
-        echo -e "${BLUE}Full report available at: $(basename "$LATEST_REPORT")${NC}"
-    fi
-fi
-
-echo ""
-echo -e "${GREEN}Done!${NC}"
+"$PYTHON_CMD" -m consistency_verifier run \
+    --suite "$SUITE" \
+    --multiwfn-bin "$MULTIWFN_EXE" \
+    --results-dir "$RESULTS_DIR" \
+    "${EXTRA_ARGS[@]}"

--- a/consistency_verifier/run_verification.py
+++ b/consistency_verifier/run_verification.py
@@ -1,59 +1,18 @@
-import os
+"""Compatibility wrapper for the manifest-driven consistency verifier."""
+
+from __future__ import annotations
+
 import sys
-from verifier import ConsistencyVerifier
+from pathlib import Path
 
-
-def main():
-    # Configuration
-    # Update this path to point to your compiled Multiwfn executable
-    # On Windows, it might be "Multiwfn.exe" if in PATH, or a full path.
-    # On Linux/WSL, it might be "./Multiwfn"
-    multiwfn_bin = os.environ.get("MULTIWFN_BIN", "Multiwfn")
-
-    # Check if Multiwfn binary exists (optional, the verifier checks too)
-    if not os.path.exists(multiwfn_bin) and not any(
-        os.access(os.path.join(path, multiwfn_bin), os.X_OK)
-        for path in os.environ["PATH"].split(os.pathsep)
-    ):
-        print(
-            f"Warning: Multiwfn binary '{multiwfn_bin}' not found. Please set MULTIWFN_BIN environment variable or edit this script."
-        )
-
-    verifier = ConsistencyVerifier(multiwfn_bin)
-
-    # Define a test case
-    # You need a sample file, e.g., 'examples/test.wfn'
-    test_file = "examples/test.wfn"
-
-    if not os.path.exists(test_file):
-        # Create a dummy test file if it doesn't exist for demonstration
-        os.makedirs("examples", exist_ok=True)
-        with open(test_file, "w") as f:
-            f.write("Dummy WFN file content")
-        print(f"Created dummy test file at {test_file}")
-
-    # Commands to send to Multiwfn
-    # Example: '1' (Show info), 'q' (Exit)
-    commands = ["1", "q"]
-
-    print(f"Verifying consistency for {test_file} with commands: {commands}")
-
-    result = verifier.verify(test_file, commands)
-
-    if result["match"]:
-        print("SUCCESS: Outputs match exactly!")
-    else:
-        print("FAILURE: Outputs do not match.")
-        print("--- Diff ---")
-        print(result["diff"])
-
-        # Save outputs for inspection
-        with open("output_ref.txt", "w") as f:
-            f.write(result["output_ref"])
-        with open("output_py.txt", "w") as f:
-            f.write(result["output_py"])
-        print("Saved outputs to output_ref.txt and output_py.txt")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from consistency_verifier.verifier import main
 
 
 if __name__ == "__main__":
-    main()
+    args = sys.argv[1:]
+    if args and args[0] in {"smoke", "pr", "full"}:
+        args = ["run", "--suite", args[0], *args[1:]]
+    elif not args or args[0].startswith("-"):
+        args = ["run", *args]
+    raise SystemExit(main(args))

--- a/consistency_verifier/simple_test.py
+++ b/consistency_verifier/simple_test.py
@@ -1,98 +1,14 @@
 #!/usr/bin/env python3
-"""
-Simple consistency test for PyMultiWFN
-Assumes PyMultiWFN is already installed in system Python
-"""
+"""Compatibility wrapper for the smoke consistency verifier suite."""
 
-import os
+from __future__ import annotations
+
 import sys
-import subprocess
-import re
+from pathlib import Path
 
-# Set Multiwfn path
-os.environ["MULTIWFN_BIN"] = (
-    "/home/yhm/software/PyMultiWFN/Multiwfn_3.8_bin_Linux_noGUI/Multiwfn"
-)
-
-# Test file
-TEST_FILE = "/home/yhm/software/PyMultiWFN/consistency_verifier/examples/H2_CCSD.wfn"
-
-
-def run_consistency_test():
-    print("=" * 60)
-    print("PyMultiWFN Consistency Simple Test")
-    print("=" * 60)
-    print(f"Test file: {TEST_FILE}")
-    print(f"Multiwfn: {os.environ.get('MULTIWFN_BIN')}")
-    print("")
-
-    # Test 1: Load with PyMultiWFN
-    print("[1/2] Loading with PyMultiWFN...")
-    try:
-        from pymultiwfn.io.file_manager import FileManager
-
-        fm = FileManager()
-        wfn = fm.load_wavefunction(TEST_FILE)
-        py_electrons = wfn.num_electrons
-        py_charge = wfn.charge
-        py_atoms = len(wfn.atoms)
-        print(f"  ✓ Electrons: {py_electrons}")
-        print(f"  ✓ Charge: {py_charge}")
-        print(f"  ✓ Atoms: {py_atoms}")
-    except Exception as e:
-        print(f"  ✗ Error: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return 1
-
-    # Test 2: Run with Multiwfn
-    print("\n[2/2] Running with Multiwfn...")
-    try:
-        result = subprocess.run(
-            [os.environ["MULTIWFN_BIN"], TEST_FILE],
-            input="18\n1\nq\n",
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        output = result.stdout
-
-        # Parse electrons from output - look for the line with total electrons
-        for line in output.split("\n"):
-            if "Total/Alpha/Beta electrons:" in line:
-                # Extract the number after the colon
-                match = re.search(r"Total/Alpha/Beta electrons:\s+([\d.]+)", line)
-                if match:
-                    mw_electrons = float(match.group(1))
-                    print(f"  ✓ Electrons: {mw_electrons}")
-                    break
-            # Also check for net charge
-            if "Net charge:" in line:
-                match = re.search(r"Net charge:\s+([\-\d.]+)", line)
-                if match:
-                    print(f"  ✓ Net charge: {match.group(1)}")
-    except Exception as e:
-        print(f"  ✗ Error: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return 1
-
-    # Compare
-    print("\n[3/3] Comparing results...")
-    if abs(py_electrons - mw_electrons) < 0.001:
-        print(f"  ✓ Electrons match: {py_electrons} == {mw_electrons}")
-        print("\n✅ CONSISTENCY CHECK PASSED")
-        print("=" * 60)
-        return 0
-    else:
-        print(f"  ✗ Electrons mismatch: {py_electrons} != {mw_electrons}")
-        print(f"    Difference: {abs(py_electrons - mw_electrons)}")
-        print("\n❌ CONSISTENCY CHECK FAILED")
-        print("=" * 60)
-        return 1
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from consistency_verifier.verifier import main
 
 
 if __name__ == "__main__":
-    sys.exit(run_consistency_test())
+    raise SystemExit(main(["run", "--suite", "smoke", *sys.argv[1:]]))

--- a/consistency_verifier/verifier.py
+++ b/consistency_verifier/verifier.py
@@ -1,21 +1,914 @@
+"""Manifest-driven consistency verification against the Multiwfn binary.
+
+The verifier treats the retained Multiwfn noGUI executable as the oracle and
+compares parsed oracle output against structured PyMultiWFN observations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import math
 import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+SUITE_ORDER = {"smoke": 0, "pr": 1, "full": 2}
+DEFAULT_TIMEOUT_SECONDS = 60
+
+DEFAULT_REFERENCE_EXTRACTORS: dict[str, dict[str, Any]] = {
+    "num_atoms": {
+        "type": "int",
+        "patterns": [
+            r"Total\s+atoms\s*:\s*(\d+)",
+            r"Number\s+of\s+atoms\s*:\s*(\d+)",
+            r"Atoms\s*:\s*(\d+)",
+        ],
+    },
+    "num_electrons": {
+        "type": "float",
+        "patterns": [
+            r"Total/Alpha/Beta\s+electrons\s*:\s*([-+]?\d+(?:\.\d+)?)",
+            r"Number\s+of\s+electrons\s*:\s*([-+]?\d+(?:\.\d+)?)",
+            r"Electrons\s*:\s*([-+]?\d+(?:\.\d+)?)",
+        ],
+    },
+    "charge": {
+        "type": "float",
+        "patterns": [
+            r"Net\s+charge\s*:\s*([-+]?\d+(?:\.\d+)?)",
+            r"Charge\s*:\s*([-+]?\d+(?:\.\d+)?)",
+        ],
+    },
+    "num_orbitals": {
+        "type": "int",
+        "patterns": [
+            r"The\s+number\s+of\s+orbitals\s*:\s*(\d+)",
+            r"Number\s+of\s+orbitals\s*:\s*(\d+)",
+            r"Molecular\s+orbitals\s*:\s*(\d+)",
+        ],
+    },
+    "num_basis": {
+        "type": "int",
+        "patterns": [
+            r"Number\s+of\s+basis\s+functions\s*:\s*(\d+)",
+            r"Basis\s+functions\s*:\s*(\d+)",
+        ],
+    },
+    "total_energy": {
+        "type": "float",
+        "patterns": [
+            r"Total\s+energy\s*:\s*([-+]?\d+(?:\.\d+)?(?:[Ee][-+]?\d+)?)",
+        ],
+    },
+}
+
+
+@dataclass(frozen=True)
+class ComparisonSpec:
+    """A single field comparison from the case manifest."""
+
+    field: str
+    kind: str = "float"
+    tolerance: float = 1e-6
+    relative_tolerance: float = 0.0
+    required: bool = True
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "ComparisonSpec":
+        return cls(
+            field=str(data["field"]),
+            kind=str(data.get("kind", "float")),
+            tolerance=float(data.get("tolerance", 1e-6)),
+            relative_tolerance=float(data.get("relative_tolerance", 0.0)),
+            required=bool(data.get("required", True)),
+        )
+
+
+@dataclass(frozen=True)
+class CaseSpec:
+    """A verifier case loaded from a JSON manifest."""
+
+    case_id: str
+    suite: str
+    input_path: Path
+    commands: list[str]
+    comparisons: list[ComparisonSpec]
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    pymultiwfn: dict[str, Any] = field(default_factory=dict)
+    reference_extractors: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any], repo_root: Path) -> "CaseSpec":
+        case_id = str(data["id"])
+        suite = str(data.get("suite", "smoke"))
+        if suite not in SUITE_ORDER:
+            raise ValueError(f"Unknown suite '{suite}' in case {case_id}")
+
+        input_path = _resolve_repo_path(repo_root, str(data["input"]))
+        multiwfn_config = data.get("multiwfn", {})
+        commands = [str(command) for command in multiwfn_config.get("commands", [])]
+        comparisons = [
+            ComparisonSpec.from_mapping(item)
+            for item in data.get("comparisons", [])
+        ]
+
+        return cls(
+            case_id=case_id,
+            suite=suite,
+            input_path=input_path,
+            commands=commands,
+            comparisons=comparisons,
+            timeout_seconds=int(
+                multiwfn_config.get(
+                    "timeout_seconds",
+                    data.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS),
+                )
+            ),
+            pymultiwfn=dict(data.get("pymultiwfn", {})),
+            reference_extractors=dict(data.get("reference_extractors", {})),
+        )
+
+
+@dataclass
+class ExecutionRecord:
+    """Captured execution details for a verifier subprocess."""
+
+    command: list[str]
+    cwd: str
+    stdin: list[str]
+    returncode: int | None
+    stdout: str
+    stderr: str
+    elapsed_seconds: float
+    timed_out: bool = False
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and not self.timed_out and self.returncode == 0
+
+
+class MultiwfnOracle:
+    """Run the retained Multiwfn executable with scripted menu commands."""
+
+    def __init__(self, binary_path: Path):
+        self.binary_path = binary_path
+
+    def run(
+        self,
+        input_path: Path,
+        commands: Iterable[str],
+        timeout_seconds: int,
+    ) -> ExecutionRecord:
+        stdin_commands = [str(command) for command in commands]
+        stdin_text = "\n".join(stdin_commands)
+        if stdin_text:
+            stdin_text += "\n"
+
+        command = [str(self.binary_path), str(input_path)]
+        start = time.perf_counter()
+
+        try:
+            completed = subprocess.run(
+                command,
+                input=stdin_text,
+                cwd=str(input_path.parent),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            elapsed = time.perf_counter() - start
+            return ExecutionRecord(
+                command=command,
+                cwd=str(input_path.parent),
+                stdin=stdin_commands,
+                returncode=None,
+                stdout=_decode_process_text(exc.stdout),
+                stderr=_decode_process_text(exc.stderr),
+                elapsed_seconds=elapsed,
+                timed_out=True,
+                error=f"Multiwfn timed out after {timeout_seconds}s",
+            )
+        except OSError as exc:
+            elapsed = time.perf_counter() - start
+            return ExecutionRecord(
+                command=command,
+                cwd=str(input_path.parent),
+                stdin=stdin_commands,
+                returncode=None,
+                stdout="",
+                stderr="",
+                elapsed_seconds=elapsed,
+                error=f"Could not execute Multiwfn: {exc}",
+            )
+
+        elapsed = time.perf_counter() - start
+        return ExecutionRecord(
+            command=command,
+            cwd=str(input_path.parent),
+            stdin=stdin_commands,
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            elapsed_seconds=elapsed,
+            error=None if completed.returncode == 0 else "Multiwfn returned non-zero",
+        )
 
 
 class ConsistencyVerifier:
-    def __init__(self, multiwfn_path):
-        self.multiwfn_path = multiwfn_path
-        print(
-            f"ConsistencyVerifier initialized with Multiwfn path: {self.multiwfn_path}"
+    """Run and compare PyMultiWFN with the original Multiwfn executable."""
+
+    def __init__(
+        self,
+        multiwfn_path: str | Path | None = None,
+        repo_root: str | Path | None = None,
+    ):
+        self.repo_root = Path(repo_root).resolve() if repo_root else _default_repo_root()
+        self.multiwfn_path = Path(multiwfn_path) if multiwfn_path else (
+            self.repo_root / "Multiwfn_3.8_bin_Linux_noGUI" / "Multiwfn"
+        )
+        if not self.multiwfn_path.is_absolute():
+            self.multiwfn_path = (self.repo_root / self.multiwfn_path).resolve()
+        self.oracle = MultiwfnOracle(self.multiwfn_path)
+
+    def verify(self, test_file: str | Path, commands: list[str]) -> dict[str, Any]:
+        """Backward-compatible single-case verification API.
+
+        Older scripts call this method directly. It now performs a real oracle
+        run and compares all common fields that can be parsed from both sides.
+        """
+        input_path = _resolve_repo_path(self.repo_root, str(test_file))
+        case = CaseSpec(
+            case_id="legacy_single_case",
+            suite="smoke",
+            input_path=input_path,
+            commands=commands,
+            comparisons=[
+                ComparisonSpec("num_atoms", "int", required=False),
+                ComparisonSpec("num_electrons", "float", tolerance=1e-6, required=False),
+                ComparisonSpec("charge", "float", tolerance=1e-6, required=False),
+                ComparisonSpec("num_orbitals", "int", required=False),
+            ],
+        )
+        result = self.run_case(case)
+        return {
+            "match": result["status"] == "passed",
+            "output_ref": result["multiwfn"]["stdout"],
+            "output_py": json.dumps(result["pymultiwfn"]["values"], indent=2),
+            "diff": _format_case_diff(result),
+            "result": result,
+        }
+
+    def run_case(self, case: CaseSpec) -> dict[str, Any]:
+        """Run one manifest case and return a JSON-serializable result."""
+        if not case.input_path.exists():
+            return {
+                "id": case.case_id,
+                "suite": case.suite,
+                "input": str(case.input_path),
+                "status": "error",
+                "error": f"Input file not found: {case.input_path}",
+                "comparisons": [],
+            }
+
+        py_started = time.perf_counter()
+        try:
+            py_values, py_warnings = collect_pymultiwfn_values(case)
+            py_error = None
+        except Exception as exc:  # pragma: no cover - exercised by CLI failures
+            py_values = {}
+            py_warnings = []
+            py_error = f"PyMultiWFN failed: {exc}"
+        py_elapsed = time.perf_counter() - py_started
+
+        oracle_record = self.oracle.run(
+            case.input_path,
+            case.commands,
+            timeout_seconds=case.timeout_seconds,
+        )
+        reference_values = extract_reference_values(
+            oracle_record.stdout,
+            _merged_extractors(case.reference_extractors),
         )
 
-    def verify(self, test_file, commands):
-        print(f"Verifying {test_file} with commands {commands}")
-        # Placeholder for actual verification logic
-        # In later phases, this will execute Multiwfn and pymultiwfn,
-        # capture outputs, and compare them.
+        comparison_results = compare_case_values(
+            case.comparisons,
+            reference_values,
+            py_values,
+        )
+
+        status = _case_status(py_error, oracle_record, comparison_results)
         return {
-            "match": True,
-            "output_ref": "ref_output",
-            "output_py": "py_output",
-            "diff": "no_diff",
+            "id": case.case_id,
+            "suite": case.suite,
+            "input": str(case.input_path),
+            "status": status,
+            "error": py_error or oracle_record.error,
+            "multiwfn": _execution_to_dict(oracle_record),
+            "pymultiwfn": {
+                "values": _json_safe(py_values),
+                "warnings": py_warnings,
+                "elapsed_seconds": py_elapsed,
+            },
+            "reference_values": _json_safe(reference_values),
+            "comparisons": comparison_results,
         }
+
+    def run_suite(
+        self,
+        suite: str,
+        cases_dir: Path,
+        results_dir: Path,
+        case_ids: set[str] | None = None,
+        write_report: bool = True,
+        skip_oracle_if_unavailable: bool = False,
+    ) -> dict[str, Any]:
+        """Run a layered suite and optionally write report artifacts."""
+        cases = load_case_specs(cases_dir, suite, self.repo_root, case_ids=case_ids)
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        run_dir = results_dir / run_id
+
+        results = []
+        for case in cases:
+            if skip_oracle_if_unavailable and not _oracle_can_run_on_host(
+                self.multiwfn_path
+            ):
+                result = _skipped_case_result(case, self.multiwfn_path)
+            else:
+                result = self.run_case(case)
+            if write_report:
+                _write_case_artifacts(run_dir, result)
+            results.append(result)
+
+        report = {
+            "run_id": run_id,
+            "suite": suite,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "repo_root": str(self.repo_root),
+            "multiwfn_bin": str(self.multiwfn_path),
+            "environment": _environment_snapshot(),
+            "summary": _summarize_results(results),
+            "cases": results,
+        }
+        if write_report:
+            run_dir.mkdir(parents=True, exist_ok=True)
+            report_path = run_dir / "report.json"
+            report_path.write_text(
+                json.dumps(_json_safe(report), indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            report["report_path"] = str(report_path)
+        return report
+
+
+def collect_pymultiwfn_values(case: CaseSpec) -> tuple[dict[str, Any], list[str]]:
+    """Load a case input with PyMultiWFN and collect structured observations."""
+    from pymultiwfn.io import load
+
+    captured_stdout = io.StringIO()
+    warnings: list[str] = []
+    with contextlib.redirect_stdout(captured_stdout):
+        wfn = load(case.input_path)
+
+    loader_output = captured_stdout.getvalue().strip()
+    if loader_output:
+        warnings.append(f"PyMultiWFN loader wrote stdout: {loader_output[:200]}")
+
+    values: dict[str, Any] = {
+        "title": wfn.title,
+        "method": wfn.method,
+        "basis_set_name": wfn.basis_set_name,
+        "num_atoms": int(wfn.num_atoms),
+        "num_electrons": float(wfn.num_electrons),
+        "charge": float(wfn.charge),
+        "multiplicity": int(wfn.multiplicity),
+        "num_basis": int(wfn.num_basis),
+        "num_atomic_orbitals": int(wfn.num_atomic_orbitals),
+        "num_primitives": int(wfn.num_primitives),
+        "num_shells": int(wfn.num_shells),
+        "num_orbitals": _infer_num_orbitals(wfn),
+    }
+
+    _collect_orbital_values(values, wfn, warnings)
+    _collect_density_values(values, wfn, case.pymultiwfn, warnings)
+    _collect_gradient_values(values, wfn, case.pymultiwfn, warnings)
+    _collect_bond_values(values, wfn, case.pymultiwfn, warnings)
+
+    return values, warnings
+
+
+def extract_reference_values(
+    output: str,
+    extractors: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Extract structured oracle values from Multiwfn text output."""
+    values: dict[str, Any] = {}
+    for field_name, extractor in extractors.items():
+        for pattern in extractor.get("patterns", []):
+            match = re.search(pattern, output, flags=re.IGNORECASE | re.MULTILINE)
+            if match:
+                values[field_name] = _coerce_value(
+                    match.group(1),
+                    str(extractor.get("type", "string")),
+                )
+                break
+    return values
+
+
+def compare_case_values(
+    comparisons: list[ComparisonSpec],
+    reference_values: dict[str, Any],
+    actual_values: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Compare all requested manifest fields."""
+    return [
+        compare_value(spec, reference_values.get(spec.field), actual_values.get(spec.field))
+        for spec in comparisons
+    ]
+
+
+def compare_value(
+    spec: ComparisonSpec,
+    expected: Any,
+    actual: Any,
+) -> dict[str, Any]:
+    """Compare one field according to its declared comparison kind."""
+    if expected is None or actual is None:
+        missing_side = "reference" if expected is None else "pymultiwfn"
+        status = "failed" if spec.required else "skipped"
+        return {
+            "field": spec.field,
+            "status": status,
+            "kind": spec.kind,
+            "expected": _json_safe(expected),
+            "actual": _json_safe(actual),
+            "required": spec.required,
+            "message": f"Missing {missing_side} value",
+        }
+
+    if spec.kind == "int":
+        passed = int(expected) == int(actual)
+        difference: int | float = int(actual) - int(expected)
+    elif spec.kind == "exact":
+        passed = expected == actual
+        difference = 0 if passed else math.nan
+    elif spec.kind == "string":
+        passed = str(expected) == str(actual)
+        difference = 0 if passed else math.nan
+    else:
+        expected_float = float(expected)
+        actual_float = float(actual)
+        difference = actual_float - expected_float
+        passed = math.isclose(
+            actual_float,
+            expected_float,
+            abs_tol=spec.tolerance,
+            rel_tol=spec.relative_tolerance,
+        )
+
+    return {
+        "field": spec.field,
+        "status": "passed" if passed else "failed",
+        "kind": spec.kind,
+        "expected": _json_safe(expected),
+        "actual": _json_safe(actual),
+        "difference": _json_safe(difference),
+        "tolerance": spec.tolerance,
+        "relative_tolerance": spec.relative_tolerance,
+        "required": spec.required,
+        "message": "ok" if passed else "values differ",
+    }
+
+
+def load_case_specs(
+    cases_dir: Path,
+    suite: str,
+    repo_root: Path,
+    case_ids: set[str] | None = None,
+) -> list[CaseSpec]:
+    """Load all JSON case manifests included in the requested suite layer."""
+    if suite not in SUITE_ORDER:
+        raise ValueError(f"Unknown suite '{suite}'")
+    if not cases_dir.exists():
+        raise FileNotFoundError(f"Cases directory not found: {cases_dir}")
+
+    selected: list[CaseSpec] = []
+    for manifest_path in sorted(cases_dir.glob("*.json")):
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        for raw_case in manifest.get("cases", []):
+            case = CaseSpec.from_mapping(raw_case, repo_root)
+            if case_ids is not None and case.case_id not in case_ids:
+                continue
+            if SUITE_ORDER[case.suite] <= SUITE_ORDER[suite]:
+                selected.append(case)
+    if not selected:
+        raise ValueError(f"No verifier cases selected for suite '{suite}'")
+    return sorted(selected, key=lambda case: (SUITE_ORDER[case.suite], case.case_id))
+
+
+def normalize_output(text: str) -> str:
+    """Normalize volatile text before creating diagnostic diffs."""
+    normalized_lines = []
+    skip_patterns = [
+        r"^\s*CPU\s+time",
+        r"^\s*Wall\s+time",
+        r"^\s*Elapsed\s+time",
+        r"^\s*Date\s*:",
+    ]
+    for line in text.replace("\r\n", "\n").splitlines():
+        if any(re.search(pattern, line, re.IGNORECASE) for pattern in skip_patterns):
+            continue
+        normalized_lines.append(re.sub(r"\s+", " ", line).strip())
+    return "\n".join(line for line in normalized_lines if line)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        verifier = ConsistencyVerifier(args.multiwfn_bin, repo_root=args.repo_root)
+        report = verifier.run_suite(
+            suite=args.suite,
+            cases_dir=Path(args.cases_dir),
+            results_dir=Path(args.results_dir),
+            case_ids=set(args.case) if args.case else None,
+            write_report=not args.no_report,
+            skip_oracle_if_unavailable=args.skip_oracle_if_unavailable,
+        )
+        _print_report_summary(report)
+        summary = report["summary"]
+        return 0 if summary["failed"] == 0 and summary["errors"] == 0 else 1
+
+    parser.print_help()
+    return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    repo_root = _default_repo_root()
+    default_cases_dir = repo_root / "consistency_verifier" / "cases"
+    default_results_dir = repo_root / "consistency_verifier" / "results"
+    default_multiwfn_bin = repo_root / "Multiwfn_3.8_bin_Linux_noGUI" / "Multiwfn"
+
+    parser = argparse.ArgumentParser(
+        prog="python -m consistency_verifier",
+        description="Run PyMultiWFN consistency checks against Multiwfn 3.8.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    run_parser = subparsers.add_parser("run", help="Run a verifier suite")
+    run_parser.add_argument(
+        "--suite",
+        choices=sorted(SUITE_ORDER),
+        default="smoke",
+        help="Layered suite to run. pr includes smoke; full includes smoke and pr.",
+    )
+    run_parser.add_argument(
+        "--multiwfn-bin",
+        default=os.environ.get("MULTIWFN_BIN", str(default_multiwfn_bin)),
+        help="Path to the Multiwfn executable oracle.",
+    )
+    run_parser.add_argument(
+        "--cases-dir",
+        default=str(default_cases_dir),
+        help="Directory containing JSON verifier case manifests.",
+    )
+    run_parser.add_argument(
+        "--results-dir",
+        default=str(default_results_dir),
+        help="Directory for generated verifier reports and transcripts.",
+    )
+    run_parser.add_argument(
+        "--repo-root",
+        default=str(repo_root),
+        help="Repository root used to resolve relative manifest paths.",
+    )
+    run_parser.add_argument(
+        "--case",
+        action="append",
+        default=[],
+        help="Run only a specific case id. May be passed multiple times.",
+    )
+    run_parser.add_argument(
+        "--no-report",
+        action="store_true",
+        help="Do not write report or transcript files.",
+    )
+    run_parser.add_argument(
+        "--skip-oracle-if-unavailable",
+        action="store_true",
+        help="Mark cases skipped instead of failing when the oracle is unavailable.",
+    )
+    return parser
+
+
+def _collect_orbital_values(
+    values: dict[str, Any],
+    wfn: Any,
+    warnings: list[str],
+) -> None:
+    if wfn.energies is None or wfn.occupations is None:
+        return
+    try:
+        from pymultiwfn.orbitals.energies import OrbitalsAnalyzer
+
+        analyzer = OrbitalsAnalyzer(wfn)
+        values["homo_index"] = int(analyzer.homo_index)
+        values["lumo_index"] = int(analyzer.lumo_index)
+        values["homo_energy"] = float(analyzer.homo_energy)
+        values["lumo_energy"] = float(analyzer.lumo_energy)
+        values["homo_lumo_gap"] = float(analyzer.gap)
+    except Exception as exc:
+        warnings.append(f"Orbital analysis unavailable: {exc}")
+
+
+def _collect_density_values(
+    values: dict[str, Any],
+    wfn: Any,
+    config: dict[str, Any],
+    warnings: list[str],
+) -> None:
+    points = config.get("density_points", [])
+    if not points:
+        return
+    try:
+        from pymultiwfn.math.density import calc_density
+
+        coords = np.array(points, dtype=float)
+        density = calc_density(wfn, coords)
+        for index, value in enumerate(density):
+            values[f"density.point_{index}"] = float(value)
+    except Exception as exc:
+        warnings.append(f"Density observations unavailable: {exc}")
+
+
+def _collect_gradient_values(
+    values: dict[str, Any],
+    wfn: Any,
+    config: dict[str, Any],
+    warnings: list[str],
+) -> None:
+    points = config.get("gradient_points", [])
+    if not points:
+        return
+    try:
+        from pymultiwfn.math.gradient import calc_density_gradient
+
+        coords = np.array(points, dtype=float)
+        gradients = calc_density_gradient(wfn, coords)
+        for index, vector in enumerate(gradients):
+            values[f"gradient.point_{index}.x"] = float(vector[0])
+            values[f"gradient.point_{index}.y"] = float(vector[1])
+            values[f"gradient.point_{index}.z"] = float(vector[2])
+            values[f"gradient.point_{index}.norm"] = float(np.linalg.norm(vector))
+    except Exception as exc:
+        warnings.append(f"Gradient observations unavailable: {exc}")
+
+
+def _collect_bond_values(
+    values: dict[str, Any],
+    wfn: Any,
+    config: dict[str, Any],
+    warnings: list[str],
+) -> None:
+    pairs = config.get("bond_pairs", [])
+    if not pairs:
+        return
+
+    try:
+        from pymultiwfn.analysis.bonding.bondorder import calculate_mayer_bond_order
+        from pymultiwfn.bonding.bonding import Bonding
+
+        mayer_matrix = calculate_mayer_bond_order(wfn).get("total")
+        bonding = Bonding(wfn)
+        for left, right in pairs:
+            left_int = int(left)
+            right_int = int(right)
+            key = f"{left_int}_{right_int}"
+            if mayer_matrix is not None:
+                values[f"mayer_bond_order.{key}"] = float(
+                    mayer_matrix[left_int - 1, right_int - 1]
+                )
+            values[f"fuzzy_bond_order.{key}"] = float(
+                bonding.get_fuzzy_bond_order(left_int, right_int)
+            )
+    except Exception as exc:
+        warnings.append(f"Bond observations unavailable: {exc}")
+
+
+def _case_status(
+    py_error: str | None,
+    oracle_record: ExecutionRecord,
+    comparisons: list[dict[str, Any]],
+) -> str:
+    if py_error or not oracle_record.ok:
+        return "error"
+    if any(item["status"] == "failed" for item in comparisons):
+        return "failed"
+    return "passed"
+
+
+def _coerce_value(value: str, value_type: str) -> Any:
+    if value_type == "int":
+        return int(float(value))
+    if value_type == "float":
+        return float(value.replace("D", "E").replace("d", "e"))
+    return value.strip()
+
+
+def _decode_process_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _environment_snapshot() -> dict[str, Any]:
+    return {
+        "python": sys.version,
+        "python_executable": sys.executable,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cwd": os.getcwd(),
+    }
+
+
+def _execution_to_dict(record: ExecutionRecord) -> dict[str, Any]:
+    return {
+        "command": record.command,
+        "cwd": record.cwd,
+        "stdin": record.stdin,
+        "returncode": record.returncode,
+        "stdout": record.stdout,
+        "stderr": record.stderr,
+        "elapsed_seconds": record.elapsed_seconds,
+        "timed_out": record.timed_out,
+        "error": record.error,
+    }
+
+
+def _format_case_diff(result: dict[str, Any]) -> str:
+    lines = []
+    for item in result.get("comparisons", []):
+        if item["status"] != "passed":
+            lines.append(
+                f"{item['field']}: {item['message']} "
+                f"(reference={item.get('expected')!r}, "
+                f"pymultiwfn={item.get('actual')!r})"
+            )
+    if lines:
+        return "\n".join(lines)
+    return "no_diff"
+
+
+def _infer_num_orbitals(wfn: Any) -> int:
+    if wfn.energies is not None:
+        return int(len(wfn.energies))
+    if wfn.coefficients is not None:
+        return int(wfn.coefficients.shape[0])
+    return int(wfn.num_basis)
+
+
+def _is_executable_file(path: Path) -> bool:
+    return path.exists() and os.access(path, os.X_OK)
+
+
+def _oracle_can_run_on_host(path: Path) -> bool:
+    if not _is_executable_file(path):
+        return False
+    if platform.system() == "Linux":
+        return True
+    try:
+        with path.open("rb") as handle:
+            return handle.read(4) != b"\x7fELF"
+    except OSError:
+        return False
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    return value
+
+
+def _merged_extractors(
+    case_extractors: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    merged = dict(DEFAULT_REFERENCE_EXTRACTORS)
+    merged.update(case_extractors)
+    return merged
+
+
+def _print_report_summary(report: dict[str, Any]) -> None:
+    summary = report["summary"]
+    print(
+        "Verifier summary: "
+        f"{summary['passed']} passed, "
+        f"{summary['failed']} failed, "
+        f"{summary['errors']} errors, "
+        f"{summary['skipped']} skipped "
+        f"({summary['total']} total)"
+    )
+    if "report_path" in report:
+        print(f"Report: {report['report_path']}")
+    for case in report["cases"]:
+        print(f"- {case['id']}: {case['status']}")
+
+
+def _resolve_repo_path(repo_root: Path, path_text: str) -> Path:
+    path = Path(path_text)
+    if path.is_absolute():
+        return path
+    return (repo_root / path).resolve()
+
+
+def _skipped_case_result(case: CaseSpec, binary_path: Path) -> dict[str, Any]:
+    return {
+        "id": case.case_id,
+        "suite": case.suite,
+        "input": str(case.input_path),
+        "status": "skipped",
+        "error": f"Oracle unavailable or not executable: {binary_path}",
+        "multiwfn": {},
+        "pymultiwfn": {"values": {}, "warnings": [], "elapsed_seconds": 0.0},
+        "reference_values": {},
+        "comparisons": [],
+    }
+
+
+def _summarize_results(results: list[dict[str, Any]]) -> dict[str, int]:
+    summary = {"total": len(results), "passed": 0, "failed": 0, "errors": 0, "skipped": 0}
+    for result in results:
+        status = result["status"]
+        if status == "passed":
+            summary["passed"] += 1
+        elif status == "failed":
+            summary["failed"] += 1
+        elif status == "skipped":
+            summary["skipped"] += 1
+        else:
+            summary["errors"] += 1
+    return summary
+
+
+def _write_case_artifacts(run_dir: Path, result: dict[str, Any]) -> None:
+    case_dir = run_dir / _safe_name(str(result["id"]))
+    case_dir.mkdir(parents=True, exist_ok=True)
+    multiwfn = result.get("multiwfn", {})
+    (case_dir / "multiwfn.stdout.txt").write_text(
+        str(multiwfn.get("stdout", "")),
+        encoding="utf-8",
+    )
+    (case_dir / "multiwfn.stderr.txt").write_text(
+        str(multiwfn.get("stderr", "")),
+        encoding="utf-8",
+    )
+    (case_dir / "pymultiwfn.values.json").write_text(
+        json.dumps(result.get("pymultiwfn", {}).get("values", {}), indent=2),
+        encoding="utf-8",
+    )
+    (case_dir / "case_result.json").write_text(
+        json.dumps(_json_safe(result), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -50,6 +50,30 @@ that retained Multiwfn reference assets are not included in the built wheel.
 
 ---
 
+## Multiwfn Oracle Consistency
+
+The retained Linux noGUI binary is the behavior oracle for parity work. Run the
+manifest-driven verifier from the repository root:
+
+```bash
+python -m consistency_verifier run --suite smoke
+python -m consistency_verifier run --suite pr
+python -m consistency_verifier run --suite full
+```
+
+`smoke` is intended for fast metadata parity, `pr` adds representative numerical
+observations, and `full` is the nightly expansion layer. Reports are generated
+under `consistency_verifier/results/`.
+
+GitHub Actions also runs the smoke oracle suite on Linux in the
+`Multiwfn Oracle Consistency` workflow and uploads generated reports.
+
+On non-Linux machines, the retained binary cannot be executed directly; run the
+harness unit tests locally and run live oracle parity in Linux CI or a Linux
+development environment.
+
+---
+
 ## Test Organization
 
 ### Test Categories

--- a/tests/test_consistency_verifier.py
+++ b/tests/test_consistency_verifier.py
@@ -1,0 +1,123 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from consistency_verifier import (
+    CaseSpec,
+    ComparisonSpec,
+    MultiwfnOracle,
+    compare_value,
+    extract_reference_values,
+    load_case_specs,
+)
+from consistency_verifier.verifier import collect_pymultiwfn_values
+
+
+def test_load_case_specs_uses_layered_suites(repo_root):
+    cases = load_case_specs(
+        repo_root / "consistency_verifier" / "cases",
+        "pr",
+        repo_root,
+    )
+    case_ids = {case.case_id for case in cases}
+
+    assert "smoke_h2_metadata" in case_ids
+    assert "pr_h2_density_gradient_orbitals" in case_ids
+    assert "full_phenanthrene_metadata" not in case_ids
+
+
+def test_extract_reference_values_from_multiwfn_output():
+    output = """
+    Total atoms: 2
+    Total/Alpha/Beta electrons: 2.000000
+    Net charge: 0.000000
+    The number of orbitals: 28
+    Total energy: -1.172345E+00
+    """
+
+    values = extract_reference_values(
+        output,
+        {
+            "num_atoms": {
+                "type": "int",
+                "patterns": [r"Total atoms:\s*(\d+)"],
+            },
+            "num_electrons": {
+                "type": "float",
+                "patterns": [r"Total/Alpha/Beta electrons:\s*([-+0-9.]+)"],
+            },
+            "num_orbitals": {
+                "type": "int",
+                "patterns": [r"The number of orbitals:\s*(\d+)"],
+            },
+            "total_energy": {
+                "type": "float",
+                "patterns": [r"Total energy:\s*([-+0-9.Ee]+)"],
+            },
+        },
+    )
+
+    assert values == {
+        "num_atoms": 2,
+        "num_electrons": 2.0,
+        "num_orbitals": 28,
+        "total_energy": pytest.approx(-1.172345),
+    }
+
+
+def test_compare_value_respects_numeric_tolerance():
+    spec = ComparisonSpec("density", kind="float", tolerance=1e-6)
+
+    passed = compare_value(spec, 1.0, 1.0 + 5e-7)
+    failed = compare_value(spec, 1.0, 1.0 + 5e-5)
+
+    assert passed["status"] == "passed"
+    assert failed["status"] == "failed"
+
+
+def test_multiwfn_oracle_captures_subprocess(monkeypatch, tmp_path):
+    input_file = tmp_path / "H2.wfn"
+    input_file.write_text("placeholder", encoding="utf-8")
+
+    def fake_run(command, **kwargs):
+        assert command == ["/oracle/Multiwfn", str(input_file)]
+        assert kwargs["input"] == "18\n1\nq\n"
+        assert kwargs["cwd"] == str(tmp_path)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="Total atoms: 2\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    record = MultiwfnOracle(Path("/oracle/Multiwfn")).run(
+        input_file,
+        ["18", "1", "q"],
+        timeout_seconds=10,
+    )
+
+    assert record.ok
+    assert record.stdout == "Total atoms: 2\n"
+    assert record.stdin == ["18", "1", "q"]
+
+
+def test_collect_pymultiwfn_values_from_retained_h2(repo_root):
+    case = CaseSpec(
+        case_id="h2_probe",
+        suite="smoke",
+        input_path=repo_root / "Multiwfn_3.8_bin_Linux_noGUI" / "examples" / "H2_CCSD.wfn",
+        commands=[],
+        comparisons=[],
+        pymultiwfn={"density_points": [[0.0, 0.0, 0.0]]},
+    )
+
+    values, warnings = collect_pymultiwfn_values(case)
+
+    assert warnings == []
+    assert values["num_atoms"] == 2
+    assert values["num_electrons"] == pytest.approx(2.0)
+    assert values["num_orbitals"] > 0
+    assert "density.point_0" in values


### PR DESCRIPTION
## Summary
- replace the stub consistency verifier with a manifest-driven Multiwfn oracle harness
- add smoke/pr/full verifier manifests and compatibility wrappers
- add a scheduled/manual Linux GitHub Actions smoke parity workflow
- document the new verifier entry points and package/reference boundaries

## Verification
- .venv/bin/pre-commit run --all-files --hook-stage pre-commit
- .venv/bin/pre-commit run --all-files --hook-stage pre-push
- .venv/bin/python -m consistency_verifier run --suite smoke --skip-oracle-if-unavailable --no-report
- .venv/bin/python -m consistency_verifier run --suite pr --skip-oracle-if-unavailable --no-report
- uv pip install -e . --python .venv/bin/python

Note: the retained oracle binary is Linux x86-64 ELF, so live oracle execution is covered by the new Linux workflow rather than local macOS.